### PR TITLE
Fix/filtered branches

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## [0.5.1] 2023-12-14
+### Changed
+ - SourceLogicTree.from_branches() returns logic tree with Branch objects rather than FilterdBranch objects
+ - remove whitespace from logic tree file paths for compatability with OpenQuake
+
 ## [0.5.0] 2023-12-12
-### Added
+## Added
  - support caching of downloads
  - build sources xml
  - migration of version1 to version2 SLT

--- a/nzshm_model/__init__.py
+++ b/nzshm_model/__init__.py
@@ -1,7 +1,7 @@
 from . import nshm_v1_0_0, nshm_v1_0_4
 
 # Python package version is different than the NSHM MODEL version !!
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 CURRENT_VERSION = "NSHM_v1.0.0"
 

--- a/nzshm_model/psha_adapter/openquake/logic_tree.py
+++ b/nzshm_model/psha_adapter/openquake/logic_tree.py
@@ -38,6 +38,7 @@ from .uncertainty_models import (
     GroundMotionUncertaintyModel,
     NshmSourceUncertaintyModel,
     SourcesUncertaintyModel,
+    _strip_whitespace,
 )
 
 NRML_NS = None
@@ -94,7 +95,7 @@ class LogicTreeBranch:
             yield _instance
 
     def path(self) -> PurePath:
-        return PurePath(self.parent.path(), self.branchID)
+        return PurePath(self.parent.path(), _strip_whitespace(self.branchID))
 
 
 @dataclass
@@ -140,7 +141,7 @@ class LogicTreeBranchSet:
         return GenericUncertaintyModel
 
     def path(self) -> PurePath:
-        return PurePath(self.parent.path(), self.branchSetID)
+        return PurePath(self.parent.path(), _strip_whitespace(self.branchSetID))
 
 
 @dataclass
@@ -156,7 +157,7 @@ class LogicTree:
             yield _instance
 
     def path(self) -> PurePath:
-        return PurePath(self.logicTreeID)
+        return PurePath(_strip_whitespace(self.logicTreeID))
 
     @classmethod
     def from_parent_slt(cls, slt: "slt.SourceLogicTree") -> "LogicTree":

--- a/nzshm_model/psha_adapter/openquake/uncertainty_models.py
+++ b/nzshm_model/psha_adapter/openquake/uncertainty_models.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
     from .logic_tree import LogicTreeBranch
 
 
+def _strip_whitespace(string: str) -> str:
+    return ''.join(string.split())
+
+
 @dataclass
 class GenericUncertaintyModel:
     parent: "LogicTreeBranch"
@@ -23,7 +27,7 @@ class GenericUncertaintyModel:
         return GenericUncertaintyModel(parent=parent, text=node.text.strip())
 
     def path(self) -> PurePath:
-        return PurePath(self.parent.path(), self.text)
+        return PurePath(self.parent.path(), _strip_whitespace(self.text))
 
 
 @dataclass
@@ -44,7 +48,7 @@ class GroundMotionUncertaintyModel:
         )
 
     def path(self) -> PurePath:
-        return PurePath(self.parent.path(), self.text)  # todo unique combination of name + args
+        return PurePath(self.parent.path(), _strip_whitespace(self.text))  # todo unique combination of name + args
 
 
 @dataclass
@@ -61,7 +65,7 @@ class SourcesUncertaintyModel:
         )
 
     def path(self) -> PurePath:
-        return PurePath(self.parent.path(), self.text)  # todo unique combination of sources
+        return PurePath(self.parent.path(), _strip_whitespace(self.text))  # todo unique combination of sources
 
 
 @dataclass
@@ -87,4 +91,4 @@ class NshmSourceUncertaintyModel:
                 )
 
     def path(self) -> PurePath:
-        return PurePath(self.parent.path(), self.toshi_nrml_id)  # todo unique combination of sources
+        return PurePath(self.parent.path(), _strip_whitespace(self.toshi_nrml_id))  # todo unique combination of sources

--- a/nzshm_model/source_logic_tree/version2/logic_tree.py
+++ b/nzshm_model/source_logic_tree/version2/logic_tree.py
@@ -7,7 +7,7 @@ import copy
 import json
 import pathlib
 from dataclasses import dataclass, field
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Type, Union, Iterator
 
 import dacite
 
@@ -50,6 +50,11 @@ class Branch:
 class FilteredBranch(Branch):
     fslt: Union['FaultSystemLogicTree', None] = None  # this should never be serialised, only used for filtering
     slt: Union['SourceLogicTree', None] = None  # this should never be serialised, only used for filtering
+
+    def to_branch(self) -> Branch:
+        branch_attributes = {k:v for k,v in self.__dict__.items() if k not in ('fslt','slt')}
+        return Branch(**branch_attributes)
+
 
 
 @dataclass
@@ -156,7 +161,7 @@ class SourceLogicTree:
             return self.__branch_list[self.__current_branch - 1]
 
     @staticmethod
-    def from_branches(branches):
+    def from_branches(branches: Iterator[FilteredBranch]) -> "SourceLogicTree":
         """
         Build a complete SLT from a iterable od branches.
 
@@ -181,5 +186,5 @@ class SourceLogicTree:
             if not fslt:
                 fslt = FaultSystemLogicTree(short_name=fb.fslt.short_name, long_name=fb.fslt.long_name)
                 slt.fault_systems.append(fslt)
-            fslt.branches.append(fb)
+            fslt.branches.append(fb.to_branch())
         return slt

--- a/nzshm_model/source_logic_tree/version2/logic_tree.py
+++ b/nzshm_model/source_logic_tree/version2/logic_tree.py
@@ -7,7 +7,7 @@ import copy
 import json
 import pathlib
 from dataclasses import dataclass, field
-from typing import Dict, List, Type, Union, Iterator
+from typing import Dict, Iterator, List, Type, Union
 
 import dacite
 
@@ -52,9 +52,8 @@ class FilteredBranch(Branch):
     slt: Union['SourceLogicTree', None] = None  # this should never be serialised, only used for filtering
 
     def to_branch(self) -> Branch:
-        branch_attributes = {k:v for k,v in self.__dict__.items() if k not in ('fslt','slt')}
+        branch_attributes = {k: v for k, v in self.__dict__.items() if k not in ('fslt', 'slt')}
         return Branch(**branch_attributes)
-
 
 
 @dataclass
@@ -177,14 +176,14 @@ class SourceLogicTree:
         for fb in branches:
             # ensure an slt
             if not slt:
-                slt = SourceLogicTree(version=fb.slt.version, title=fb.slt.title)
+                slt = SourceLogicTree(version=fb.slt.version, title=fb.slt.title)  # type: ignore
             else:
-                assert slt.version == fb.slt.version
+                assert slt.version == fb.slt.version  # type: ignore
 
             # ensure an fslt
             fslt = match_fslt(slt, fb)
             if not fslt:
-                fslt = FaultSystemLogicTree(short_name=fb.fslt.short_name, long_name=fb.fslt.long_name)
+                fslt = FaultSystemLogicTree(short_name=fb.fslt.short_name, long_name=fb.fslt.long_name)  # type: ignore
                 slt.fault_systems.append(fslt)
             fslt.branches.append(fb.to_branch())
-        return slt
+        return slt  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nzshm-model"
-version = "0.5.0"
+version = "0.5.1"
 description = "The logic tree definitions, final configurations, and versioning of the New Zealand | Aotearoa National Seismic Hazard Model"
 authors = ["Chris DiCaprio <c.dicaprio@gns.cri.nz>", "Chris Chamberlain <chrisbc@artisan.co.nz>"]
 license = "AGPL3"

--- a/tests/psha_adapter/openquake/test_logic_tree_from_model.py
+++ b/tests/psha_adapter/openquake/test_logic_tree_from_model.py
@@ -52,7 +52,7 @@ def test_source_logic_tree():
     assert src_logic_tree.branch_sets[0].branches[0].uncertainty_weight == pytest.approx(0.210000)
     assert (
         src_logic_tree.branch_sets[0].branches[0].path()
-        == PurePath('SLT_v9p0p0') / "PUY" / "[dm0.7, bN[0.902, 4.6], C4.0, s0.28]"
+        == PurePath('SLT_v9p0p0') / "PUY" / "[dm0.7,bN[0.902,4.6],C4.0,s0.28]"
     )
 
 
@@ -67,7 +67,7 @@ def test_source_logic_tree_uncertainty_PUY():
 
     assert src_logic_tree.branch_sets[BSID].branchSetID == "PUY"
     assert src_logic_tree.branch_sets[BSID].branches[0].path() == PurePath(
-        'SLT_v9p0p0', 'PUY', '[dm0.7, bN[0.902, 4.6], C4.0, s0.28]'
+        'SLT_v9p0p0', 'PUY', '[dm0.7,bN[0.902,4.6],C4.0,s0.28]'
     )
 
     assert len(src_logic_tree.branch_sets[BSID].branches[0].uncertainty_models) == 2
@@ -101,7 +101,7 @@ def test_source_logic_tree_uncertainty_SLAB():
     BSID = 3
 
     assert src_logic_tree.branch_sets[BSID].branchSetID == "SLAB"
-    assert src_logic_tree.branch_sets[BSID].branches[0].path() == PurePath('SLT_v9p0p0', 'SLAB', '[runiform, d1]')
+    assert src_logic_tree.branch_sets[BSID].branches[0].path() == PurePath('SLT_v9p0p0', 'SLAB', '[runiform,d1]')
 
     assert len(src_logic_tree.branch_sets[BSID].branches[0].uncertainty_models) == 1
 
@@ -119,7 +119,7 @@ def test_source_logic_tree_uncertainty_CRU():
     BSID = 2
     assert src_logic_tree.branch_sets[BSID].branchSetID == "CRU"
     assert src_logic_tree.branch_sets[BSID].branches[0].path() == PurePath(
-        'SLT_v9p0p0/CRU/[dmgeodetic, tdFalse, bN[0.823, 2.7], C4.2, s0.66]'
+        'SLT_v9p0p0/CRU/[dmgeodetic,tdFalse,bN[0.823,2.7],C4.2,s0.66]'
     )
     assert len(src_logic_tree.branch_sets[BSID].branches[0].uncertainty_models) == 2
 

--- a/tests/psha_adapter/openquake/test_logic_tree_from_xml.py
+++ b/tests/psha_adapter/openquake/test_logic_tree_from_xml.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePath
 import pytest
 
 from nzshm_model.psha_adapter import NrmlDocument
+from nzshm_model.psha_adapter.openquake.uncertainty_models import _strip_whitespace
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures"
 
@@ -56,15 +57,14 @@ def test_nrml_gmm_logic_tree_paths():
         "lt1",
         "bs_crust",
         "STF22_upper",
-        '[Stafford2022]\n                  mu_branch = "Upper"',
+        '[Stafford2022]mu_branch="Upper"',
     )
 
     assert doc.logic_trees[0].branch_sets[1].branches[0].uncertainty_models[0].path() == PurePath(
         "lt1",
         "bs_slab",
         "Kuehn2020SS_GLO_lower",
-        '[KuehnEtAl2020SSlab]\n                        region = "GLO"'
-        '\n                        sigma_mu_epsilon = -1.28155',
+        '[KuehnEtAl2020SSlab]region="GLO"' 'sigma_mu_epsilon=-1.28155',
     )
 
 
@@ -161,5 +161,8 @@ def test_nrml_srm_logic_tree_path(
     assert doc.logic_trees[0].branch_sets[0].branches[0].path() == PurePath(logic_tree_id, branch_set_id, branch_id)
 
     assert doc.logic_trees[0].branch_sets[0].branches[0].uncertainty_models[0].path() == PurePath(
-        logic_tree_id, branch_set_id, branch_id, uncertainty_model
+        _strip_whitespace(logic_tree_id),
+        _strip_whitespace(branch_set_id),
+        _strip_whitespace(branch_id),
+        _strip_whitespace(uncertainty_model),
     )

--- a/tests/test_slt_filtering.py
+++ b/tests/test_slt_filtering.py
@@ -5,6 +5,7 @@ import pytest
 
 import nzshm_model
 from nzshm_model.source_logic_tree import SourceLogicTree
+from nzshm_model.source_logic_tree.version2 import Branch
 
 
 ## three example filter functions
@@ -67,3 +68,4 @@ def test_build_slt_from_filtered_slt(full_slt):
     print(slt)
     assert len(slt.fault_systems) == 1
     assert len(slt.fault_systems[0].branches) == 9
+    assert type(slt.fault_systems[0].branches[0]) is Branch  # isinstance() not used to avoid true for inherited classes


### PR DESCRIPTION
* `SourceLogicTree.from_branches` returns an object with `Branch` types not `FilteredBranch` types
* logic tree file paths have no whitespace for OQ compatability
* update type hints