### PR TITLE
add GHA support for python 310 and 311 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        python-versions: [3.9]
-        os: [ubuntu-latest]
+        python-versions: [3.9, '3.10', '3.11']
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/nzshm_model/logic_tree/gmcm_logic_tree/logic_tree.py
+++ b/nzshm_model/logic_tree/gmcm_logic_tree/logic_tree.py
@@ -48,5 +48,5 @@ class GMCMLogicTree(LogicTree):
 
 @dataclass
 class GMCMFilteredBranch(FilteredBranch, GMCMBranch):
-    logic_tree: 'GMCMLogicTree' = GMCMLogicTree()
-    branch_set: 'GMCMBranchSet' = GMCMBranchSet()
+    logic_tree: 'GMCMLogicTree' = field(default_factory=GMCMLogicTree)
+    branch_set: 'GMCMBranchSet' = field(default_factory=GMCMBranchSet)

--- a/nzshm_model/logic_tree/source_logic_tree/version2/logic_tree.py
+++ b/nzshm_model/logic_tree/source_logic_tree/version2/logic_tree.py
@@ -237,8 +237,8 @@ class SourceFilteredBranch(FilteredBranch, SourceBranch):
 
     """
 
-    logic_tree: 'LogicTree' = SourceLogicTree()
-    branch_set: 'BranchSet' = SourceBranchSet()
+    logic_tree: 'LogicTree' = field(default_factory=SourceLogicTree)
+    branch_set: 'BranchSet' = field(default_factory=SourceBranchSet)
 
     @property
     def fslt(self) -> 'BranchSet':


### PR DESCRIPTION
closing #41 
- for python 311 dataclasses need default_factory;
- adds GHA test coverage for macos-latest and windows-latest
- adds GHA test coverage for python3.10 and 3.11