### PR TITLE
add branch_id SourceLogicTree v1->v2 conversion, required for correla…

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.13.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.13.1] 2024-09-09
+
+### Added
+ - cli command to convert SourceLogicTree v1 module files to v2 json files
+
+### Changed
+ - add branch_id when converting from SourceLogicTree v1 to v2
+
 ## [0.13.0] 2024-08-21
 
 ### Changed

--- a/nzshm_model/__init__.py
+++ b/nzshm_model/__init__.py
@@ -43,4 +43,4 @@ from .model import NshmModel
 from .model_version import CURRENT_VERSION, all_model_versions, get_model_version, versions
 
 # Python package version is different than the NSHM MODEL version !!
-__version__ = '0.13.0'
+__version__ = '0.13.1'

--- a/nzshm_model/logic_tree/source_logic_tree/logic_tree.py
+++ b/nzshm_model/logic_tree/source_logic_tree/logic_tree.py
@@ -202,9 +202,12 @@ class SourceLogicTree(LogicTree):
         slt = SourceLogicTree(version=original_slt.version, title=original_slt.title)
         for fslt in original_slt.fault_systems:
             new_fslt = SourceBranchSet(short_name=fslt.short_name, long_name=fslt.long_name)
+            branch_id = 0
             for branch in fslt.branches:
-                # TODO: handle rate scaling
-                new_branch = SourceBranch(values=copy.deepcopy(branch.values), weight=branch.weight)
+                new_branch = SourceBranch(
+                    values=copy.deepcopy(branch.values), weight=branch.weight, branch_id=str(branch_id)
+                )
+                branch_id += 1
                 if branch.onfault_nrml_id:
                     new_branch.sources.append(
                         InversionSource(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
 
 [tool.poetry.scripts]
 slt = 'scripts.slt:slt'
+model = 'scripts.cli:cli'
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nzshm-model"
-version = "0.13.0"
+version = "0.13.1"
 description = "The logic tree definitions, final configurations, and versioning of the New Zealand | Aotearoa National Seismic Hazard Model"
 authors = ["Chris DiCaprio <c.dicaprio@gns.cri.nz>", "Chris Chamberlain <chrisbc@artisan.co.nz>"]
 license = "AGPL3"

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -8,7 +8,9 @@ import click
 import nzshm_model
 
 # from nzshm_model.source_logic_tree import SourceLogicTree
+import nzshm_model.logic_tree
 from nzshm_model.logic_tree.source_logic_tree import SourceLogicTree
+from nzshm_model.logic_tree.source_logic_tree.version1.slt_config import from_config
 
 # from nzshm_model.source_logic_tree.slt_config import from_config, resolve_toshi_source_ids  # noqa
 from nzshm_model.psha_adapter.openquake import OpenquakeSourcePshaAdapter
@@ -53,6 +55,21 @@ def fetch(cache_folder, model_id):
         click.echo(item)
 
     click.echo('DONE')
+
+
+@cli.command()
+@click.argument('module-path')
+@click.argument('json-path')
+@click.option('--title', '-t')
+@click.option('--version', '-v')
+def convert(module_path, json_path, title, version):
+    """Convert an old-style source logic tree defined as a python module to a new style
+    JSON logic tree file.
+    """
+
+    slt_v1 = from_config(module_path, version=version, title=title)
+    slt = SourceLogicTree.from_source_logic_tree(slt_v1)
+    slt.to_json(json_path)
 
 
 @cli.command()

--- a/tests/test_slt_version_migration.py
+++ b/tests/test_slt_version_migration.py
@@ -22,6 +22,15 @@ def test_migrate_NSHM_v1_0_4(slt_version_1):
     v2 = SourceLogicTree.from_source_logic_tree(slt_version_1)
     assert v2.version == slt_version_1.version
 
+def test_migrate_serialize_deserialize(slt_version_1, tmp_path):
+
+    slt_filepath = tmp_path / 'slt.json'
+    v2 = SourceLogicTree.from_source_logic_tree(slt_version_1)
+    v2.to_json(slt_filepath)
+    v2_deserialized = SourceLogicTree.from_json(slt_filepath)
+
+    assert v2_deserialized == v2
+
 
 def test_migrate_NSHM_v1_0_4_fault_systems(slt_version_1):
     v2 = SourceLogicTree.from_source_logic_tree(slt_version_1)


### PR DESCRIPTION
To convert a v1 SourceLogicTree defined in a python module to a v2 SourceLogicTree where the correlations work and it can be written to json, we need to add unique branch_id values to the branches.

Add cli command to convert v1 SLT module to v2 SLT json