### PR TITLE
136 set sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
  - `config_from_oq_ini` method in `OpenquakeConfigPshaAdapter` class to create an `OpenquakeConfig` object from an OpenQuake ini configuration file.
 
+### Changed
+ - `OpenquakeConfig.set_sites` calculates z-values (z1pt0 and z2pt5) if vs30 provided but z-values are not.
+ - `OpenquakeConfig.set_sites` will not raise an exception if uniform site parameters have been set.
+ - `OpenquakeConfig.set_uniform_site_params` will not raise an exception if site-specific parameters have been set.
+
  ### Removed
  - python3.9 support
 

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -258,11 +258,11 @@ class OpenquakeConfig(HazardConfig):
         self.config.set("calculation", "maximum_distance", str(value_new))
         return self
 
-    def set_sites(self, locations: Iterable[CodedLocation], **site_paramiters) -> 'OpenquakeConfig':
+    def set_sites(self, locations: Iterable[CodedLocation], **site_parameters) -> 'OpenquakeConfig':
         """Set the site locations at which hazard is calculated. Optionally set site parameters.
 
         If vs30 is passed as a site_parameter but z1pt0 and/or z2pt5 are not passed they will be calculated
-        from vs30. z1.0 is caculated using Chiou & Youngs (2014) California model and z2.5 is caclualted using
+        from vs30. z1.0 is caculated using Chiou & Youngs (2014) California model and z2.5 is calculated using
         Campbell & Bozorgnia 2014 NGA-West2 model.
 
         Arguments:
@@ -287,7 +287,7 @@ class OpenquakeConfig(HazardConfig):
             Ground Motion and Response Spectra.' Earthquake Spectra. 30. 1117-1153.
         """
 
-        site_params = copy.copy(site_paramiters)
+        site_params = copy.copy(site_parameters)
         if "vs30" in site_params and "z1pt0" not in site_params:
             site_params["z1pt0"] = [calculate_z1pt0(vs30) for vs30 in site_params["vs30"]]
         if "vs30" in site_params and "z2pt5" not in site_params:

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -463,36 +463,31 @@ class OpenquakeConfig(HazardConfig):
 
         if z1pt0:
             sect['reference_depth_to_1pt0km_per_sec'] = str(round(z1pt0, 0))
-        else:
+        elif 'calculate_z1pt0' in globals():
             sect['reference_depth_to_1pt0km_per_sec'] = str(round(calculate_z1pt0(vs30), 0))
 
         if z2pt5:
             sect['reference_depth_to_2pt5km_per_sec'] = str(round(z2pt5, 1))
-        else:
+        elif 'calculate_z2pt5' in globals():
             sect['reference_depth_to_2pt5km_per_sec'] = str(round(calculate_z2pt5(vs30), 1))
 
         return self
 
-    def get_uniform_site_params(self) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+    def get_uniform_site_params(self) -> Optional[Tuple[float, float, float]]:
         """
         The uniform site parameters of the model. Returns None if not set.
 
         Returns:
             (vs30, z1pt0, z2pt5) where vs30 is the vs30 applied to all sites, z1pt0 is the z1.0 reference
-            depth in m, and z2pt5 is the z2.5 reference depth in km.
+            depth in m, and z2pt5 is the z2.5 reference depth in km. Returns None if uniform site parameters are not set
         """
 
-        if not self.config.has_section('site_params'):
-            return None, None, None
+        if not self.config.has_section('site_params') or not self.config.get('site_params', 'reference_vs30_value'):
+            return None
 
-        value = self.get_parameter('site_params', 'reference_vs30_value')
-        vs30 = float(value) if value else None
-
-        value = self.config.get('site_params', 'reference_depth_to_1pt0km_per_sec', fallback=None)
-        z1pt0 = float(value) if value else None
-
-        value = self.config.get('site_params', 'reference_depth_to_2pt5km_per_sec', fallback=None)
-        z2pt5 = float(value) if value else None
+        vs30 = float(self.config.get('site_params', 'reference_vs30_value'))
+        z1pt0 = float(self.config.get('site_params', 'reference_depth_to_1pt0km_per_sec'))
+        z2pt5 = float(self.config.get('site_params', 'reference_depth_to_2pt5km_per_sec'))
 
         return vs30, z1pt0, z2pt5
 

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -279,6 +279,7 @@ class OpenquakeConfig(HazardConfig):
             raise KeyError(
                 "Cannot set site specific vs30, z1.0, or, z2.5: configuration specifies uniform site conditions."
             )
+        if 'vs30' in site_parameters and 
         if 'z1pt0' in site_parameters and self.config.has_option('site_params', 'reference_depth_to_1pt0km_per_sec'):
             raise KeyError(
                 "Cannot set site specific vs30, z1.0, or, z2.5: configuration specifies uniform site conditions."
@@ -463,12 +464,12 @@ class OpenquakeConfig(HazardConfig):
 
         if z1pt0:
             sect['reference_depth_to_1pt0km_per_sec'] = str(round(z1pt0, 0))
-        elif 'calculate_z1pt0' in globals():
+        else:
             sect['reference_depth_to_1pt0km_per_sec'] = str(round(calculate_z1pt0(vs30), 0))
 
         if z2pt5:
             sect['reference_depth_to_2pt5km_per_sec'] = str(round(z2pt5, 1))
-        elif 'calculate_z2pt5' in globals():
+        else:
             sect['reference_depth_to_2pt5km_per_sec'] = str(round(calculate_z2pt5(vs30), 1))
 
         return self

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -289,9 +289,9 @@ class OpenquakeConfig(HazardConfig):
 
         site_params = copy.copy(site_parameters)
         if "vs30" in site_params and "z1pt0" not in site_params:
-            site_params["z1pt0"] = [calculate_z1pt0(vs30) for vs30 in site_params["vs30"]]
+            site_params["z1pt0"] = [round(calculate_z1pt0(vs30), 0) for vs30 in site_params["vs30"]]
         if "vs30" in site_params and "z2pt5" not in site_params:
-            site_params["z2pt5"] = [calculate_z2pt5(vs30) for vs30 in site_params["vs30"]]
+            site_params["z2pt5"] = [round(calculate_z2pt5(vs30), 1) for vs30 in site_params["vs30"]]
 
         self._site_parameters = {}
         locations = tuple(locations)

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -261,6 +261,9 @@ class OpenquakeConfig(HazardConfig):
     def set_sites(self, locations: Iterable[CodedLocation], **site_parameters) -> 'OpenquakeConfig':
         """Set the site locations at which hazard is calculated. Optionally set site parameters.
 
+        Any site specific parameters will take precedence over the uniform values set with the
+        set_uniform_site_params method.
+
         If vs30 is passed as a site_parameter but z1pt0 and/or z2pt5 are not passed they will be calculated
         from vs30. z1.0 is caculated using Chiou & Youngs (2014) California model and z2.5 is calculated using
         Campbell & Bozorgnia 2014 NGA-West2 model.
@@ -429,7 +432,8 @@ class OpenquakeConfig(HazardConfig):
         self, vs30: float, z1pt0: Optional[float] = None, z2pt5: Optional[float] = None
     ) -> 'OpenquakeConfig':
         """
-        Setter for vs30, z1.0, and z2.5 site parameters.
+        Setter for uniform vs30, z1.0, and z2.5 site parameters. These parameters are applied to every
+        site unless any site specific values are set with the set_sites method which take precedence.
 
         This will set the vs30, z1.0, and z2.5 site parameters for all sites. If z1pt0 and/or z2pt5
         are not specified they will be calculated from vs30. z1.0 is caculated using Chiou & Youngs

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -482,7 +482,7 @@ class OpenquakeConfig(HazardConfig):
             depth in m, and z2pt5 is the z2.5 reference depth in km. Returns None if uniform site parameters are not set
         """
 
-        if not self.config.has_section('site_params') or not self.config.get('site_params', 'reference_vs30_value'):
+        if not self.config.has_section('site_params') or not self.config.get('site_params', 'reference_vs30_value', fallback=None):
             return None
 
         vs30 = float(self.config.get('site_params', 'reference_vs30_value'))

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -258,7 +258,7 @@ class OpenquakeConfig(HazardConfig):
         self.config.set("calculation", "maximum_distance", str(value_new))
         return self
 
-    def set_sites(self, locations: Iterable[CodedLocation], **site_paramiterss) -> 'OpenquakeConfig':
+    def set_sites(self, locations: Iterable[CodedLocation], **site_paramiters) -> 'OpenquakeConfig':
         """Set the site locations at which hazard is calculated. Optionally set site parameters.
 
         If vs30 is passed as a site_parameter but z1pt0 and/or z2pt5 are not passed they will be calculated
@@ -267,11 +267,11 @@ class OpenquakeConfig(HazardConfig):
 
         Arguments:
             locations: The surface locations of the sites.
-            kwargs: Additional site parameters to include.
-                    Argument names will be used in the site file header. All entries
-                    must be a sequence of the same length as locations.  See
-                    https://docs.openquake.org/oq-engine/manual/latest/user-guide/inputs/site-model-inputs.html
-                    for a list of valid site parameters.
+            **site_parameters: Site parameters for the locations (optional). Keyword argument names will be used
+                as the parameter name in the site file header. All entries must be a sequence of the same
+                length as locations. See
+                https://docs.openquake.org/oq-engine/manual/latest/user-guide/inputs/site-model-inputs.html
+                for a list of valid site parameters.
 
         Returns:
             The OpenquakeConfig instance.
@@ -287,7 +287,7 @@ class OpenquakeConfig(HazardConfig):
             Ground Motion and Response Spectra.' Earthquake Spectra. 30. 1117-1153.
         """
 
-        site_params = copy.copy(site_paramiterss)
+        site_params = copy.copy(site_paramiters)
         if "vs30" in site_params and "z1pt0" not in site_params:
             site_params["z1pt0"] = [calculate_z1pt0(vs30) for vs30 in site_params["vs30"]]
         if "vs30" in site_params and "z2pt5" not in site_params:

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -7,7 +7,6 @@ Module supporting managed openquake configuration files
 
 """
 import ast
-import copy
 import configparser
 import copy
 import json
@@ -285,7 +284,7 @@ class OpenquakeConfig(HazardConfig):
 
             Chiou, Brian & Youngs, Robert. (2014).
             'Update of the Chiou and Youngs NGA Model for the Average Horizontal Component of Peak
-            Ground Motion and Response Spectra.' Earthquake Spectra. 30. 1117-1153. 
+            Ground Motion and Response Spectra.' Earthquake Spectra. 30. 1117-1153.
         """
 
         site_params = copy.copy(site_paramiterss)
@@ -485,7 +484,9 @@ class OpenquakeConfig(HazardConfig):
             depth in m, and z2pt5 is the z2.5 reference depth in km. Returns None if uniform site parameters are not set
         """
 
-        if not self.config.has_section('site_params') or not self.config.has_option('site_params', 'reference_vs30_value'):
+        if not self.config.has_section('site_params') or not self.config.has_option(
+            'site_params', 'reference_vs30_value'
+        ):
             return None
 
         vs30 = float(self.config.get('site_params', 'reference_vs30_value'))

--- a/nzshm_model/psha_adapter/openquake/hazard_config.py
+++ b/nzshm_model/psha_adapter/openquake/hazard_config.py
@@ -463,12 +463,12 @@ class OpenquakeConfig(HazardConfig):
 
         if z1pt0:
             sect['reference_depth_to_1pt0km_per_sec'] = str(round(z1pt0, 0))
-        elif 'calculate_z1pt0' in globals():
+        else:
             sect['reference_depth_to_1pt0km_per_sec'] = str(round(calculate_z1pt0(vs30), 0))
 
         if z2pt5:
             sect['reference_depth_to_2pt5km_per_sec'] = str(round(z2pt5, 1))
-        elif 'calculate_z2pt5' in globals():
+        else:
             sect['reference_depth_to_2pt5km_per_sec'] = str(round(calculate_z2pt5(vs30), 1))
 
         return self

--- a/tests/psha_adapter/openquake/test_openquake_config.py
+++ b/tests/psha_adapter/openquake/test_openquake_config.py
@@ -208,10 +208,7 @@ def test_unset_uniform_site_params():
     vs30_in = 100
     config.set_uniform_site_params(vs30_in)
     config.unset_uniform_site_params()
-    vs30, z1pt0, z2pt5 = config.get_uniform_site_params()
-    assert vs30 is None
-    assert z1pt0 is None
-    assert z2pt5 is None
+    assert config.get_uniform_site_params() is None
 
 
 def test_site_errors(locations):

--- a/tests/psha_adapter/openquake/test_openquake_config.py
+++ b/tests/psha_adapter/openquake/test_openquake_config.py
@@ -223,22 +223,6 @@ def test_site_errors(locations):
     with pytest.raises(ValueError):
         config.set_sites(locations, vs30=[100] * (n_locs + 1))
 
-    # cannot set site specific vs30 if uniform is specified
-    config = OpenquakeConfig()
-    config.set_uniform_site_params(100)
-
-    assert config.set_sites(locations)
-
-    vs30 = list(range(n_locs))
-    with pytest.raises(KeyError):
-        config.set_sites(locations, vs30=vs30)
-
-    # cannot set uniform vs30 if site specific
-    config = OpenquakeConfig()
-    config.set_sites(locations, vs30=vs30)
-    with pytest.raises(KeyError):
-        config.set_uniform_site_params(100)
-
 
 class TestConfigCompatability:
     def test_compatible_check_invariants(self, example_config):
@@ -328,7 +312,7 @@ def test_write_read_oq_config(tmp_path):
 def test_write_read_oq_config_site_params(tmp_path):
     config = OpenquakeConfig(DEFAULT_HAZARD_CONFIG)
     locations = [CodedLocation(lat, lon, 0.001) for lat, lon in zip(range(10), range(10))]
-    vs30s = [v / 10.0 for v in range(len(locations))]
+    vs30s = [(v + 1.0) / 10.0 for v in range(len(locations))]
     config.set_sites(locations, vs30=vs30s)
 
     json_filepath = tmp_path / 'hazard_config.json'

--- a/tests/psha_adapter/openquake/test_openquake_read_config.py
+++ b/tests/psha_adapter/openquake/test_openquake_read_config.py
@@ -22,7 +22,7 @@ def config_site_specific(locations) -> OpenquakeConfig:
     imtls = [float(i) for i in list(range(10))]
     config.set_iml(imts, imtls)
 
-    vs30s = [v / 10.0 for v in range(len(locations))]
+    vs30s = [(v + 1.0) / 10.0 for v in range(len(locations))]
     config.set_sites(locations, vs30=vs30s)
 
     return config

--- a/tests/psha_adapter/openquake/test_oq_adapters.py
+++ b/tests/psha_adapter/openquake/test_oq_adapters.py
@@ -3,7 +3,7 @@ import warnings
 
 import pytest
 
-from nzshm_model.psha_adapter.openquake.hazard_config import OpenquakeConfig
+from nzshm_model.psha_adapter.openquake.hazard_config import OpenquakeConfig, calculate_z1pt0, calculate_z2pt5
 from nzshm_model.psha_adapter.openquake.hazard_config_compat import DEFAULT_HAZARD_CONFIG
 from nzshm_model.psha_adapter.openquake.simple_nrml import (
     OpenquakeConfigPshaAdapter,
@@ -40,7 +40,7 @@ def test_config_adapter(tmp_path, locations):
 def test_config_sitefile(tmp_path, locations):
     site_file = tmp_path / 'sites1.csv'
     hazard_config = OpenquakeConfig(DEFAULT_HAZARD_CONFIG)
-    vs30s = [v / 10.0 for v in range(len(locations))]
+    vs30s = [(v + 1) / 10.0 for v in range(len(locations))]
     hazard_config.set_sites(locations, vs30=vs30s)
     config_adapter = hazard_config.psha_adapter(OpenquakeConfigPshaAdapter)
     config_adapter.write_site_file(site_file)
@@ -48,11 +48,13 @@ def test_config_sitefile(tmp_path, locations):
     with site_file.open() as fin:
         reader = csv.reader(fin)
         header = next(reader)
-        assert header == ['lon', 'lat', 'vs30']
+        assert header == ['lon', 'lat', 'vs30', 'z1pt0', 'z2pt5']
         for loc, vs30, row in zip(locations, vs30s, reader):
             assert row[0] == str(loc.lon)
             assert row[1] == str(loc.lat)
             assert row[2] == str(vs30)
+            assert row[3] == str(calculate_z1pt0(vs30))
+            assert row[4] == str(calculate_z2pt5(vs30))
 
 
 @pytest.mark.filterwarnings("default")

--- a/tests/psha_adapter/openquake/test_oq_adapters.py
+++ b/tests/psha_adapter/openquake/test_oq_adapters.py
@@ -53,8 +53,8 @@ def test_config_sitefile(tmp_path, locations):
             assert row[0] == str(loc.lon)
             assert row[1] == str(loc.lat)
             assert row[2] == str(vs30)
-            assert row[3] == str(calculate_z1pt0(vs30))
-            assert row[4] == str(calculate_z2pt5(vs30))
+            assert row[3] == str(round(calculate_z1pt0(vs30), 0))
+            assert row[4] == str(round(calculate_z2pt5(vs30), 1))
 
 
 @pytest.mark.filterwarnings("default")


### PR DESCRIPTION
closes #136 
closes #135 

- uniform and site specific site parameters are now allowed simultaneously (same behaviour as OpenQuake)
- `set_sites` treats vs30 and z values (z1pt0, z2pt5) same as `set_uniform_site_params`: if a vs30 value is provided, but one or both z values are not, the z values are calculated using Chiou & Youngs (2014) and Campbell & Bozorgnia (2014).

re #135, setting site specific values does not overwrite the reference site values and `reference_vs30_type = measured` is a default value if using `DEFAULT_HAZARD_CONFIG`. Setting uniform values with `set_uniform_site_params` will also set reference_vs30_type = measured` . Still need to discuss if it should be part of the `ENTRIES_INVARIANT` (#143)