### PR TITLE
Feature/154 branchid

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.2
+current_version = 0.15.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.15.0] 2026-04-08
+### Changed
+ - `OpenquakeSourcePshaAdapter` uses branch `registry_identity` for branchID rather than `str(values)`
+
 ## [0.14.1] 2026-01-20
 ### Added
  - `audit` environment for tox

--- a/nzshm_model/__init__.py
+++ b/nzshm_model/__init__.py
@@ -44,4 +44,4 @@ from .model import NshmModel
 from .model_version import CURRENT_VERSION, all_model_versions, get_model_version, versions
 
 # Python package version is different than the NSHM MODEL version !!
-__version__ = '0.14.2'
+__version__ = '0.15.0'

--- a/nzshm_model/psha_adapter/openquake/simple_nrml.py
+++ b/nzshm_model/psha_adapter/openquake/simple_nrml.py
@@ -237,7 +237,7 @@ class OpenquakeSourcePshaAdapter(SourcePshaAdapterInterface):
         for fs in self.source_logic_tree.branch_sets:
             ltbs = LTBS(uncertaintyType="sourceModel", branchSetID=fs.short_name)
             for branch in fs.branches:
-                branch_name = str(branch.values)
+                branch_name = branch.registry_identity
                 files = ""
                 ltv = getattr(self.source_logic_tree, "logic_tree_version", 0)
                 if ltv >= 2:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nzshm-model"
-version = "0.14.2"
+version = "0.15.0"
 description = "The logic tree definitions, final configurations, and versioning of the New Zealand | Aotearoa National Seismic Hazard Model"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
closes #154 

This does not break `toshi-hazard-store` function `build_rlz_source_map` as that function falls back on using the branch identity which is a sorted list of source nrml IDs separated by `"|"`. Judging by the comments, it is likely this is the expected OQ behavior for the THS function. https://github.com/GNS-Science/toshi-hazard-store/blob/a09a7206ae88e19d175b9ac76e33a3964bf3c2e5/toshi_hazard_store/oq_import/parse_oq_realizations.py#L97